### PR TITLE
Reset properties in TrustBadgeManager.initialize()

### DIFF
--- a/OrangeTrustBadge/Classes/Manager/TrustBadgeManager.swift
+++ b/OrangeTrustBadge/Classes/Manager/TrustBadgeManager.swift
@@ -290,6 +290,13 @@ open class TrustBadgeManager: NSObject {
     
     func initialize(){
         
+        self.terms = []
+        self.mainElements = []
+        self.otherElements = []
+        self.usageElements = []
+        self.css = ""
+        self.appName = ""
+
         //initialize main Elements
         if let mainElements = self.config?.mainElements{
             self.mainElements.append(contentsOf: mainElements)


### PR DESCRIPTION
This allows calling TrustBadgeManager.with(_:) static method several times