### PR TITLE
add a pageDidLoad closure parameter in TrustBadgeConfig

### DIFF
--- a/OrangeTrustBadge/Classes/Manager/TrustBadgeManager.swift
+++ b/OrangeTrustBadge/Classes/Manager/TrustBadgeManager.swift
@@ -152,6 +152,13 @@ open class TrustBadgeConfig : NSObject{
     open lazy var terms = [Term]()
     
     /**
+     Closure called when a page is displayed (optional).
+     - Parameters:
+     - pageName: the name of the page
+     */
+    open var pageDidAppear: ((_ pageName: String) -> Void)?
+
+    /**
      Closure to get the localized string for a wording key.
      - Parameters:
      - key: The wording key to localize.
@@ -421,6 +428,10 @@ open class TrustBadgeManager: NSObject {
                 }
             }
         }
+    }
+
+    func pageDidAppear(_ pageName: String) -> Void {
+        config?.pageDidAppear?(pageName)
     }
 
     func localizedString(_ key: String) -> String {

--- a/OrangeTrustBadge/Classes/UI/Landing/LandingController.swift
+++ b/OrangeTrustBadge/Classes/UI/Landing/LandingController.swift
@@ -59,6 +59,11 @@ class LandingController: UITableViewController {
         self.tableView.reloadData()
     }
     
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+        TrustBadgeManager.sharedInstance.pageDidAppear("Landing")
+    }
+
     override func willTransition(to newCollection: UITraitCollection, with coordinator: UIViewControllerTransitionCoordinator) {
         self.manageLogoVisibility()
         self.tableView.reloadData()

--- a/OrangeTrustBadge/Classes/UI/Permissions/PermissionsController.swift
+++ b/OrangeTrustBadge/Classes/UI/Permissions/PermissionsController.swift
@@ -55,6 +55,11 @@ class PermissionsController: UITableViewController {
         NotificationCenter.default.post(name: Notification.Name(rawValue: TrustBadgeManager.TRUSTBADGE_PERMISSION_ENTER), object: nil)
     }
     
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+        TrustBadgeManager.sharedInstance.pageDidAppear("Permissions")
+    }
+
     // MARK: - Table view data source
     
     override func numberOfSections(in tableView: UITableView) -> Int {

--- a/OrangeTrustBadge/Classes/UI/Terms/TermsController.swift
+++ b/OrangeTrustBadge/Classes/UI/Terms/TermsController.swift
@@ -51,6 +51,11 @@ class TermsController: UITableViewController {
         players = [String : DailymotionPlayer]()
     }
     
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+        TrustBadgeManager.sharedInstance.pageDidAppear("Terms")
+    }
+
     // MARK: - Table view data source
     
     override func numberOfSections(in tableView: UITableView) -> Int {

--- a/OrangeTrustBadge/Classes/UI/Usages/UsagesController.swift
+++ b/OrangeTrustBadge/Classes/UI/Usages/UsagesController.swift
@@ -46,6 +46,11 @@ class UsagesController: UITableViewController {
         NotificationCenter.default.post(name: Notification.Name(rawValue: TrustBadgeManager.TRUSTBADGE_USAGE_ENTER), object: nil)
     }
     
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+        TrustBadgeManager.sharedInstance.pageDidAppear("Usages")
+    }
+
     // MARK: - Table view data source
     
     override func numberOfSections(in tableView: UITableView) -> Int {


### PR DESCRIPTION
This parameter is used by pageDidLoad(_:) methods of view controllers.