### PR TITLE
Problems in view controllers headers

### DIFF
--- a/OrangeTrustBadge/Classes/UI/Permissions/PermissionsController.swift
+++ b/OrangeTrustBadge/Classes/UI/Permissions/PermissionsController.swift
@@ -43,7 +43,7 @@ class PermissionsController: UITableViewController {
         self.tableView.register(UINib(nibName: "ElementCell", bundle: Bundle(for: TrustBadgeConfig.self)), forCellReuseIdentifier: ElementCell.reuseIdentifier)
         tableView.estimatedRowHeight = 65
 
-        tableView.configure(header: header, with: TrustBadgeManager.sharedInstance.localizedString("permission-header-title"))
+        tableView.configure(header: header, with: TrustBadgeManager.sharedInstance.localizedString("permission-header-title"), and: TrustBadgeManager.sharedInstance.config?.headerTextColor)
         
         NotificationCenter.default.addObserver(self, selector: #selector(PermissionsController.refresh), name: NSNotification.Name.UIApplicationWillEnterForeground, object: nil)
         

--- a/OrangeTrustBadge/Classes/UI/Terms/TermsController.swift
+++ b/OrangeTrustBadge/Classes/UI/Terms/TermsController.swift
@@ -38,7 +38,7 @@ class TermsController: UITableViewController {
         navigationItem.leftBarButtonItem = splitViewController?.displayModeButtonItem
         navigationItem.leftItemsSupplementBackButton = true
         tableView.estimatedRowHeight = 100       
-        tableView.configure(header: header, with: TrustBadgeManager.sharedInstance.localizedString("terms-header-title"))
+        tableView.configure(header: header, with: TrustBadgeManager.sharedInstance.localizedString("terms-header-title"), and: TrustBadgeManager.sharedInstance.config?.headerTextColor)
 
         if #available(iOS 11, *) {
             self.tableView.contentInsetAdjustmentBehavior = .never

--- a/OrangeTrustBadge/Classes/UI/Usages/UsagesController.swift
+++ b/OrangeTrustBadge/Classes/UI/Usages/UsagesController.swift
@@ -38,7 +38,7 @@ class UsagesController: UITableViewController {
         navigationItem.leftItemsSupplementBackButton = true
         self.tableView.register(UINib(nibName: "ElementCell", bundle: Bundle(for: TrustBadgeConfig.self)), forCellReuseIdentifier: ElementCell.reuseIdentifier)
         tableView.estimatedRowHeight = 65       
-        tableView.configure(header: header, with: TrustBadgeManager.sharedInstance.localizedString("usages-header-title"))
+        tableView.configure(header: header, with: TrustBadgeManager.sharedInstance.localizedString("usages-header-title"), and: TrustBadgeManager.sharedInstance.config?.headerTextColor)
 
         if #available(iOS 11, *) {
             self.tableView.contentInsetAdjustmentBehavior = .never

--- a/OrangeTrustBadge/Resources/OrangeTrustBadge.storyboard
+++ b/OrangeTrustBadge/Resources/OrangeTrustBadge.storyboard
@@ -359,7 +359,7 @@
                             <rect key="frame" x="0.0" y="0.0" width="375" height="130"/>
                             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                             <subviews>
-                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="249" verticalHuggingPriority="750" horizontalCompressionResistancePriority="749" text="landing-header-title" textAlignment="justified" lineBreakMode="wordWrap" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="hcO-M2-S3Q">
+                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="249" verticalHuggingPriority="750" horizontalCompressionResistancePriority="749" text="landing-header-title" textAlignment="natural" lineBreakMode="wordWrap" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="hcO-M2-S3Q">
                                     <rect key="frame" x="15" y="15" width="257" height="18"/>
                                     <fontDescription key="fontDescription" type="boldSystem" pointSize="15"/>
                                     <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>


### PR DESCRIPTION
Fixed a problem where the headerTextColor configuration was not used in PermissionsController, TermsController and UsagesController

Changed text alignment, in the Landing page header text label, to "natural" instead of "justified" as this value is used everywhere else but here.