### PR TITLE
Fix/bug swift UI

### DIFF
--- a/OrangeTrustBadge/Classes/UI/Terms/TermsController.swift
+++ b/OrangeTrustBadge/Classes/UI/Terms/TermsController.swift
@@ -35,7 +35,7 @@ class TermsController: UITableViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
-
+        self.view.backgroundColor = .white
         if let splitViewController = self.splitViewController {
             navigationItem.leftBarButtonItem = splitViewController.displayModeButtonItem
             navigationItem.leftItemsSupplementBackButton = true

--- a/OrangeTrustBadge/Classes/UI/Terms/TermsController.swift
+++ b/OrangeTrustBadge/Classes/UI/Terms/TermsController.swift
@@ -35,7 +35,15 @@ class TermsController: UITableViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
-        self.view.backgroundColor = .white
+        if #available(iOS 13.0, *) {
+              
+            if self.traitCollection.userInterfaceStyle == .dark {
+                    self.view.backgroundColor = UIColor.black
+            } else {
+                    self.view.backgroundColor = UIColor.white
+            }
+
+        }
         if let splitViewController = self.splitViewController {
             navigationItem.leftBarButtonItem = splitViewController.displayModeButtonItem
             navigationItem.leftItemsSupplementBackButton = true


### PR DESCRIPTION
OMNIS (my Orange) project  use trustBadge to display permission used in the apps, 
since in the project we use SwiftUI (not UIkit) so there is a problem with color background view  when we display "Our commitment" is displayed with "Clear" Color . 


![193251793_218897170047874_7159892628095826200_n](https://user-images.githubusercontent.com/18083556/120403482-929eb880-c344-11eb-88d9-4f09a0f997b4.png)

PS @anthonynevo 